### PR TITLE
Update AlienRaceSettings.xml

### DIFF
--- a/Common/Defs/AlienRaceSettings/AlienRaceSettings.xml
+++ b/Common/Defs/AlienRaceSettings/AlienRaceSettings.xml
@@ -1,80 +1,105 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<AlienRace.RaceSettings>
-		<defName>Mousekin_RaceSettings</defName>
-		<pawnKindSettings>
-			<startingColonists>
-				<li>
-					<pawnKindEntries>
-						<li>
-							<kindDefs>
-								<li>MousekinColonist</li>
-							</kindDefs>
-							<chance>20.0</chance>
-						</li>
-						<li>
-							<kindDefs>
-								<li>MousekinTradesman</li>
-							</kindDefs>
-							<chance>30.0</chance>
-						</li>
-						<li>
-							<kindDefs>
-								<li>MousekinGuardener</li>
-							</kindDefs>
-							<chance>20.0</chance>
-						</li>	
-						<li>
-							<kindDefs>
-								<li>MousekinDoctor</li>
-							</kindDefs>
-							<chance>10.0</chance>
-						</li>					
-						<li>
-							<kindDefs>
-								<li>MousekinPeasant</li>
-							</kindDefs>
-							<chance>20.0</chance>
-						</li>
-						<li>
-							<kindDefs>
-								<li>MousekinPriest</li>
-							</kindDefs>
-							<chance>10.0</chance>
-						</li>
-					</pawnKindEntries>
-					<factionDefs>
-						<li>Mousekin_PlayerFaction_Settlers</li>
-						<li>Mousekin_PlayerFaction_Refugees</li>
-					</factionDefs>
-				</li>
-			</startingColonists>
-			<alienslavekinds>
-				<li>
-					<kindDefs>
-						<li>MousekinSlave</li>
-					</kindDefs>
-					<chance>10.0</chance>
-				</li>
-			</alienslavekinds>
-			<alienwandererkinds>
-				<li>
-					<pawnKindEntries>
-						<li>
-							<kindDefs>
-								<li>MousekinWanderer</li>
-							</kindDefs>
-							<chance>50.0</chance>
-						</li>
-					</pawnKindEntries>
-					<factionDefs>
-						<li>Mousekin_FactionKingdom</li>
-						<li>Mousekin_FactionIndyTown</li>
-					</factionDefs>
-				</li>
-			</alienwandererkinds>
-		</pawnKindSettings>
-	</AlienRace.RaceSettings>
+  <!--
+    RaceSettings for Mousekin, defining the pawn kinds
+    that appear as starting colonists, slaves, or wanderers.
+  -->
+
+  <AlienRace.RaceSettings>
+    <defName>Mousekin_RaceSettings</defName>
+
+    <!-- PawnKindSettings: controlling spawn chances for various scenarios. -->
+    <pawnKindSettings>
+
+      <!-- Starting Colonists: 
+           Defines which pawn kinds can appear when the player starts a new colony 
+           with Mousekin factions.
+      -->
+      <startingColonists>
+        <li>
+          <!-- Pawn kind entries for the starting colonists -->
+          <pawnKindEntries>
+            <li>
+              <kindDefs>
+                <li>MousekinColonist</li>
+              </kindDefs>
+              <chance>20.0</chance>
+            </li>
+            <li>
+              <kindDefs>
+                <li>MousekinTradesman</li>
+              </kindDefs>
+              <chance>30.0</chance>
+            </li>
+            <li>
+              <kindDefs>
+                <li>MousekinGuardener</li>
+              </kindDefs>
+              <chance>20.0</chance>
+            </li>
+            <li>
+              <kindDefs>
+                <li>MousekinDoctor</li>
+              </kindDefs>
+              <chance>10.0</chance>
+            </li>
+            <li>
+              <kindDefs>
+                <li>MousekinPeasant</li>
+              </kindDefs>
+              <chance>20.0</chance>
+            </li>
+            <li>
+              <kindDefs>
+                <li>MousekinPriest</li>
+              </kindDefs>
+              <chance>10.0</chance>
+            </li>
+          </pawnKindEntries>
+
+          <!-- The factions where these kinds can appear as starting colonists -->
+          <factionDefs>
+            <li>Mousekin_PlayerFaction_Settlers</li>
+            <li>Mousekin_PlayerFaction_Refugees</li>
+          </factionDefs>
+        </li>
+      </startingColonists>
+
+      <!-- Slave kinds:
+           Pawn kinds that may appear as slaves, presumably in hostile or trade contexts.
+      -->
+      <alienslavekinds>
+        <li>
+          <kindDefs>
+            <li>MousekinSlave</li>
+          </kindDefs>
+          <chance>10.0</chance>
+        </li>
+      </alienslavekinds>
+
+      <!-- Wanderer kinds:
+           Pawn kinds that appear as wanderers, visitors, or quest refugees from 
+           the Mousekin society.
+      -->
+      <alienwandererkinds>
+        <li>
+          <pawnKindEntries>
+            <li>
+              <kindDefs>
+                <li>MousekinWanderer</li>
+              </kindDefs>
+              <chance>50.0</chance>
+            </li>
+          </pawnKindEntries>
+          <factionDefs>
+            <li>Mousekin_FactionKingdom</li>
+            <li>Mousekin_FactionIndyTown</li>
+          </factionDefs>
+        </li>
+      </alienwandererkinds>
+
+    </pawnKindSettings>
+  </AlienRace.RaceSettings>
 
 </Defs>


### PR DESCRIPTION
Below is a refined version of your XML file for RimWorld’s AlienRace RaceSettings. The structure is the same, but it’s formatted with consistent indentation, spacing, and optional comments. Feel free to add or remove any elements to fit your specific needs:

What’s Changed & Why
Consistent Indentation & Spacing

Each nested element is indented, making the hierarchy clearer and easier to read. Comments

Comments before major sections (<startingColonists>, <alienslavekinds>, <alienwandererkinds>) explain the purpose of each block. Element Ordering

Kept the existing order but grouped logically (kinds, chance, faction definitions), making it easier to spot changes or additions. Clearer Naming

Left your IDs and def names unchanged but used comments to highlight their function. No Structural Changes

The structure remains the same (no rename or removal), so existing references in your mod or other patches won’t break. This version is more readable and maintainable while preserving the same logic and data as your original code.